### PR TITLE
file:// support for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .DS_Store
+.idea/
 

--- a/src/android/DocumentHandler.java
+++ b/src/android/DocumentHandler.java
@@ -1,6 +1,10 @@
 package ch.ti8m.phonegap.plugins;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -136,7 +140,13 @@ public class DocumentHandler extends CordovaPlugin {
 
 		@Override
 		protected File doInBackground(Void... arg0) {
-			return downloadFile(url, callbackContext);
+			if(!url.startsWith("file://")){
+                return downloadFile(url, callbackContext);
+            }
+            else{
+                File file = new File(url.replaceFirst("file://", ""));
+                return file;
+            }
 		}
 
 		@Override


### PR DESCRIPTION
DocumentHandler handles file:// url on iOS but not on Android trying
every time to download the resource at the given url. Added a shorcut
for Android when the url is already a local file which doesn’t need to
be downloaded.
